### PR TITLE
Duplicate signals sent fix

### DIFF
--- a/signal_producer.js
+++ b/signal_producer.js
@@ -1,0 +1,34 @@
+const AWS = require('aws-sdk');
+AWS.config.accessKeyId = process.env.AWS_KEY;
+AWS.config.secretAccessKey = process.env.AWS_SECRET;
+
+const sqs = new AWS.SQS({ region: 'us-east-1' });
+var queueURL = 'https://sqs.us-east-1.amazonaws.com/983584755688/intelligenttrading-sqs-production'; //process.env.SQS_PROD;
+
+
+var messageBody = {
+    type: "trade signal",
+    coin: "ETH",
+    risk: "high",
+    signal: "SMA",
+    trend: "1",
+    strength: "2",
+    strength_max: "3",
+    horizon: "medium",
+    price: "0.00045",
+    price_change: "0.012"
+};
+
+var params = {
+    DelaySeconds: 10,
+    MessageBody: JSON.stringify(messageBody),
+    QueueUrl: queueURL
+};
+
+sqs.sendMessage(params, function (err, data) {
+    if (err) {
+        console.log("Error", err);
+    } else {
+        console.log("Success", data.MessageId);
+    }
+});

--- a/telegram_dispatch.js
+++ b/telegram_dispatch.js
@@ -63,7 +63,9 @@ function notify(message) {
           var data = JSON.parse(body)
           data.chat_ids.forEach((chat_id) => {
             if (chat_id != undefined) {
-              bot.sendMessage(chat_id, telegram_signal_message);
+              bot.sendMessage(chat_id, telegram_signal_message).catch((err)=>{
+                console.log(err);
+              });
             }
           });
         }

--- a/test/t_push_signal.js
+++ b/test/t_push_signal.js
@@ -11,7 +11,7 @@ function Signal(type, risk, signal, coin, trend, strength, strength_max, horizon
     this.type = type;
     this.risk = risk;
     this.signal = signal;
-    this.coin = coin;    
+    this.coin = coin;
     this.trend = trend;
     this.strength = strength;
     this.strength_max = strength_max;
@@ -23,10 +23,12 @@ function Signal(type, risk, signal, coin, trend, strength, strength_max, horizon
 //push_sma_signal("ETH",1,2,3,"medium",0.00123,0.05)
 var tester = {
     push_trade_signal: (type, risk, signal, coin, trend, strength, strength_max, horizon, price, price_change) => {
-        var message_data =  new Signal(type, risk, signal, coin, trend, strength, strength_max, horizon, price, price_change);
-        queue.push(production_queue_name, message_data);
-        console.log(JSON.stringify(message_data));
+        var message_data = new Signal(type, risk, signal, coin, trend, strength, strength_max, horizon, price, price_change);
+        queue.push(production_queue_name, message_data, () =>
+            console.log('Sending ' + JSON.stringify(message_data)));
     },
 }
+
+setInterval(() => tester.push_trade_signal("trade signal", "high", "ETH", 1, 2, 3, "medium", 0.00123, 0.05), 2000);
 
 exports.signal_tester = tester;


### PR DESCRIPTION
A cache keeps the IDs of the messages for 30 seconds in order to check
if duplicate signals are going to be sent and keep the consumer
idempotent. Fix #9  