### PR TITLE
[FIX] Missing chat id

### DIFF
--- a/telegram_dispatch.js
+++ b/telegram_dispatch.js
@@ -68,7 +68,7 @@ function notify(message_data) {
                   bot.sendMessage(chat_id, telegram_signal_message, opts)
                     .catch((err) => {
                       var errMessage = `${err.message} :: chat ${chat_id}`;
-                      throw new Error(errMessage)
+                      console.log(errMessage);
                     });
                 }
               });
@@ -83,6 +83,9 @@ function notify(message_data) {
           else {
             console.log(error);
           }
+        })
+        .catch((reason) => {
+          console.log(reason);
         });
     }
   }


### PR DESCRIPTION
The bot was throwing an error instead of soft-handling it with a
console log